### PR TITLE
Add TimetablePresenterJson to write JSON formatted output to files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ serde = { version = "1.0", features = ["derive"] }
 quick-xml = { version = "0.23.0", features = ["serialize"] }
 chrono = { version = "0.4.19" }
 merge = { version = "0.1.0" }
+serde_json = { version = "1.0" }

--- a/src/app.rs
+++ b/src/app.rs
@@ -42,7 +42,7 @@ impl App {
 
             match self.xmlparser.get_timetable(&timetable_changes) {
                 Ok(changes) => {
-                    self.presenter.present(&changes);
+                    self.presenter.present(&changes, &eva);
                 }
                 Err(_) => (),
             }

--- a/src/timetablepresenter.rs
+++ b/src/timetablepresenter.rs
@@ -1,5 +1,5 @@
 use crate::timetable::Timetable;
 
 pub trait TimetablePresenter {
-    fn present(&self, timetable: &Timetable);
+    fn present(&self, timetable: &Timetable, eva: &String);
 }

--- a/src/timetablepresenterconsole.rs
+++ b/src/timetablepresenterconsole.rs
@@ -12,7 +12,7 @@ impl TimetablePresenterConsole {
 }
 
 impl TimetablePresenter for TimetablePresenterConsole {
-    fn present(&self, timetable: &Timetable) {
+    fn present(&self, timetable: &Timetable, _eva: &String) {
         print_station_name(timetable);
         print_seperator_lines(2);
         print_timetablestop(timetable);

--- a/src/timetablepresenterjson.rs
+++ b/src/timetablepresenterjson.rs
@@ -1,0 +1,133 @@
+use crate::timetable::{ArrivalDeparture, Timetable};
+use crate::timetablepresenter::TimetablePresenter;
+use chrono::NaiveDateTime;
+use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::io::{BufWriter, Write};
+
+#[derive(Serialize, Deserialize)]
+struct TimetableStop {
+    station: String,
+    train: String,
+    end_station: String,
+    planned_time: String,
+    actual_time: String,
+}
+
+pub struct TimetablePresenterJson();
+
+impl TimetablePresenterJson {
+    #[allow(dead_code)]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl TimetablePresenter for TimetablePresenterJson {
+    fn present(&self, timetable: &Timetable, eva: &String) {
+        let station = get_station_name(timetable);
+        let stops = get_stops(timetable, &station);
+        let json = to_json(&stops);
+        write_to_file(&eva, &json);
+    }
+}
+
+fn get_station_name(timetable: &Timetable) -> String {
+    return format!(
+        "{}",
+        timetable
+            .station
+            .as_ref()
+            .unwrap_or(&"Station name missing".to_string())
+    );
+}
+
+fn get_stops(timetable: &Timetable, station: &String) -> Vec<TimetableStop> {
+    let mut stops = Vec::new();
+    timetable
+        .s
+        .as_ref()
+        .unwrap()
+        .iter()
+        .for_each(|s| match &s.dp {
+            Some(dp) => match &s.tl {
+                Some(tl) => {
+                    let train_name = get_train_name(tl, dp);
+                    let end_station = get_train_end_station(dp);
+                    let planned_time = get_planned_time(dp);
+                    let changed_time = get_changed_time(dp);
+
+                    stops.push(TimetableStop {
+                        station: station.clone(),
+                        train: train_name.clone(),
+                        end_station: end_station.clone(),
+                        planned_time: planned_time.clone(),
+                        actual_time: changed_time.clone(),
+                    });
+                }
+                None => {}
+            },
+            None => {}
+        });
+
+    stops
+}
+
+fn get_train_name(
+    tl: &crate::timetable::Triplabel,
+    dp: &crate::timetable::ArrivalDeparture,
+) -> String {
+    let c =
+        tl.c.as_ref()
+            .unwrap_or(tl.n.as_ref().unwrap_or(&"".to_string()))
+            .to_string();
+    let l =
+        dp.l.as_ref()
+            .unwrap_or(tl.n.as_ref().unwrap_or(&"".to_string()))
+            .to_string();
+
+    return match (!c.is_empty(), !l.is_empty()) {
+        (true, true) => format!("{}{}", c, l),
+        _ => "Train name missing".to_string(),
+    };
+}
+
+fn get_train_end_station(dp: &ArrivalDeparture) -> String {
+    return format!(
+        "{}",
+        dp.ppth
+            .as_ref()
+            .unwrap_or(&"".to_string())
+            .split('|')
+            .last()
+            .unwrap_or(&"".to_string())
+    );
+}
+
+fn get_planned_time(dp: &ArrivalDeparture) -> String {
+    return format!(
+        "{}",
+        NaiveDateTime::parse_from_str(dp.pt.as_ref().unwrap_or(&"-".to_string()), "%y%m%d%H%M")
+            .unwrap()
+            .to_string()
+    );
+}
+
+fn get_changed_time(dp: &crate::timetable::ArrivalDeparture) -> String {
+    match NaiveDateTime::parse_from_str(dp.ct.as_ref().unwrap_or(&"-".to_string()), "%y%m%d%H%M") {
+        Ok(dt) => return format!("{}", dt.to_string()),
+        _ => return format!("No delay"),
+    }
+}
+
+fn to_json(stops: &Vec<TimetableStop>) -> String {
+    let j = serde_json::to_string(&stops);
+    format!("{}", j.unwrap_or_default())
+}
+
+fn write_to_file(eva: &String, json: &String) {
+    let filename = format!("{}.json", &eva);
+    let f = File::create(filename).expect("Unable to create file");
+    let mut f = BufWriter::new(f);
+    f.write_all(json.as_bytes()).expect("Unable to write data");
+}


### PR DESCRIPTION
TimetablePresenterJson writes the timetable output to a JSON formatted text file. The file is located next to the binary and is named after the EVA number of the station. A seperate file for each station is created.