### PR TITLE
Load default config when loading local config file fails

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1", features = ["full"] }
-confy = { version = "0.3.1" }
+confy = { version = "0.5.1" }
 serde = { version = "1.0", features = ["derive"] }
 quick-xml = { version = "0.23.0", features = ["serialize"] }
 chrono = { version = "0.4.19" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,9 +14,19 @@ use xmlparser::XmlParser;
 
 extern crate confy;
 
+fn load_config() -> Config {
+    match confy::load("dbtimetable", "config") {
+        Ok(config) => config,
+        Err(e) => {
+            eprintln!("Error loading config: {}. Using default config", e);
+            Config::default()
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
-    let config: Config = confy::load("dbtimetable")?;
+    let config = load_config();
     let apiclient = DbApiClient::new(config.clone());
     let xmlparser = XmlParser::new();
     let presenter = Box::new(TimetablePresenterConsole::new());


### PR DESCRIPTION
This also updates depency confy to version 0.5.1. Old version 0.3.1. had an unhandled panic in confy::load

closes #5 